### PR TITLE
modification parsing regex fix

### DIFF
--- a/CsvParser.py
+++ b/CsvParser.py
@@ -713,7 +713,7 @@ class CsvParser:
             # ToDo: check against unimod?
 
             try:
-                modifications = re.search('([^A-Z]+)', ''.join([pepseq1, pepseq2])).groups()
+                modifications = re.findall('[^A-Z]+', ''.join([pepseq1, pepseq2]))
             except AttributeError:
                 modifications = []
 

--- a/FullCsvParser.py
+++ b/FullCsvParser.py
@@ -464,7 +464,7 @@ class FullCsvParser(AbstractCsvParser):
             # ToDo: check against unimod?
 
             try:
-                modifications = re.search('([^A-Z]+)', ''.join([pepseq1, pepseq2])).groups()
+                modifications = re.findall('[^A-Z]+', ''.join([pepseq1, pepseq2]))
             except AttributeError:
                 modifications = []
 


### PR DESCRIPTION
When the backend parses a csv-defined pepseq for modifications, the regex as defined will only capture the first match in each string, because while re.search() allows the match to start at any point, only a single capture is defined (there's no '+' outside the parentheses) and furthermore, since only lower-case letters can match, the whole regex can only match up to the end of the first lower-case letter sequence.

The code as written is slightly dichotomous in that it actually returns a single-item tuple from calling .groups() on the match if there is at least one match, but in the case of no match, falls through to returning an empty list (although this discrepancy is functionally irrelevant as both can be iterated through in the subsequent loop). Based on the subsequent code in both these files (and the presumably intended behaviour), in parser.py, and in the browser side js handling the ajax response, I believe 'modifications' is expected to be a list (and subsequently a javascript array) of every lower case modification string in the pepseq.

The apparently intended functionality of a list of lower-case modifications (as strings) can be achieved without the need for subgroup capturing via re.findall().

```
>>> import re
>>> pepseq = "EKbs3nh2GPQVCcmAKLFGNIQK"
>>> re.search('([^A-Z]+)',pepseq).groups()
('bs3nh2',)
>>> re.findall('[^A-Z]+',pepseq)
['bs3nh2', 'cm']
```

Assuming I have interpreted branch names correctly, and correctly assumed what's currently live at https://xiview.org/, this should be a fix for Rappsilber-Laboratory/xiView_container#23